### PR TITLE
add rAF tests, with and without frame counting

### DIFF
--- a/experiment/rAF.html
+++ b/experiment/rAF.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <style>
+    html {
+      background-color: black;
+      color: white;
+    }
+    #stim {
+      position: absolute;
+      top: calc(50% - 100px);
+      left: calc(50% - 100px);
+      width: 200px;
+      height: 200px;
+      visibility: hidden;
+      background-color: white;
+    }
+    #config {
+      position: absolute;
+      top: 50px;
+      left: calc(50% - 200px);
+      width: 400px;
+      height: 200px;
+      border: 1px solid #ccc;
+      text-align: center;
+    }
+  </style>
+</head>
+<body>
+  <div id="config">
+    <p>Stimulus Duration: <input type="number" id="duration"></input></p>
+    <p>ITI: <input type="number" id="iti"></input></p>
+    <p>Trials: <input type="number" id="trials"></input></p>
+    <button id="start">Start</button>
+  </div>
+  <div id="stim"></div>
+</body>
+<script>
+
+var duration = 0;
+var iti = 0;
+var trials = 0;
+
+document.querySelector('#start').addEventListener('click', function(){
+  duration = document.querySelector('#duration').value;
+  iti = document.querySelector('#iti').value;
+  trials = document.querySelector('#trials').value;
+
+  document.querySelector('#config').remove();
+  
+  setTimeout(next, 1000);
+
+});
+
+function hideStim() {
+  if (typeof rAF_reference !== 'undefined') {
+    window.cancelAnimationFrame(rAF_reference);
+  }
+  document.querySelector('#stim').style.visibility = 'hidden';
+
+  trials--;
+  if (trials === 0) {
+    done();
+  } else {
+    setTimeout(next, iti);
+  }
+}
+
+function checkForTimeouts(timestamp, intended_delay, event_fn) {
+  var curr_delay = timestamp - start_time; 
+  if (curr_delay >= intended_delay) {
+    event_fn();
+  } else {
+    rAF_reference = window.requestAnimationFrame(function(timestamp) {
+      checkForTimeouts(timestamp, intended_delay, event_fn);});
+  }
+}
+
+function next() {
+  window.requestAnimationFrame(function(timestamp) {
+    document.querySelector('#stim').style.visibility = 'visible';
+    start_time = performance.now();
+    var rAF_reference = window.requestAnimationFrame(function(timestamp) {
+      checkForTimeouts(timestamp, duration - 5, hideStim);
+    });
+  });  
+}
+
+function done() {
+  document.querySelector('html').style.height = "calc(100vh - 60px)";
+  document.querySelector('html').style.borderWidth = "30px";
+  document.querySelector('html').style.borderColor = "green";
+  document.querySelector('html').style.borderStyle = "solid";
+}
+
+</script>
+</html>

--- a/experiment/rAF_frame_counting.html
+++ b/experiment/rAF_frame_counting.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <style>
+    html {
+      background-color: black;
+      color: white;
+    }
+    #stim {
+      position: absolute;
+      top: calc(50% - 100px);
+      left: calc(50% - 100px);
+      width: 200px;
+      height: 200px;
+      visibility: hidden;
+      background-color: white;
+    }
+    #config {
+      position: absolute;
+      top: 50px;
+      left: calc(50% - 200px);
+      width: 400px;
+      height: 200px;
+      border: 1px solid #ccc;
+      text-align: center;
+    }
+    #wait {
+      position: absolute;
+      top: 50px;
+      left: calc(50% - 200px);
+      width: 400px;
+      text-align: center;
+      visibility: hidden;
+    }
+  </style>
+</head>
+<body>
+  <div id="config">
+    <p>Stimulus Duration: <input type="number" id="duration"></input></p>
+    <p>ITI: <input type="number" id="iti"></input></p>
+    <p>Trials: <input type="number" id="trials"></input></p>
+    <button id="start">Start</button>
+  </div>
+  <div id="wait"><p>Calculating frame rate. Please wait...</p></div>
+  <div id="stim"></div>
+</body>
+<script>
+
+var duration = 0;
+var iti = 0;
+var trials = 0;
+var frame_count = 0;
+var estimated_frame_duration;
+var fps_est_n_trials = 1000;
+var frame_times = new Array(fps_est_n_trials);
+var frame_diffs = new Array(fps_est_n_trials-1);
+
+function estimateFramesPerSec(timestamp, callback) {      
+  document.querySelector('#wait').style.visibility = 'visible';
+  // from http://jsfiddle.net/bn8kbw3t/
+  if (frame_count > 0) {
+    var last_time = frame_times[frame_count-1];
+    frame_diffs[frame_count-1] = timestamp - last_time; 
+  }
+  frame_times[frame_count] = timestamp;
+  if (frame_count == fps_est_n_trials) {
+    var sum = frame_diffs.reduce(function(a, b) {return a + b;});
+    var avg = sum / (frame_diffs.length);
+    estimated_frame_duration = avg;
+    document.querySelector('#wait').remove();
+    callback();
+  } else {
+    frame_count++;
+    window.requestAnimationFrame(function(timestamp) {estimateFramesPerSec(timestamp, callback);});
+  }
+}
+
+document.querySelector('#start').addEventListener('click', function(){
+  duration = document.querySelector('#duration').value;
+  iti = document.querySelector('#iti').value;
+  trials = document.querySelector('#trials').value;
+
+  document.querySelector('#config').remove();
+  
+  window.requestAnimationFrame(function(timestamp) {
+    estimateFramesPerSec(timestamp, next);
+  });
+});
+
+function hideStim() {
+  if (typeof rAF_reference !== 'undefined') {
+    window.cancelAnimationFrame(rAF_reference);
+  }
+  document.querySelector('#stim').style.visibility = 'hidden';
+
+  trials--;
+  if (trials === 0) {
+    done();
+  } else {
+    setTimeout(next, iti);
+  }
+}
+
+function checkForTimeouts(timestamp, intended_delay, intended_frame_count, event_fn) {
+  var curr_delay = timestamp - start_time; 
+  var frame_diff = frame_count - intended_frame_count;
+  var time_diff = curr_delay - intended_delay;
+  if ((frame_diff >= 0 && time_diff >= -estimated_frame_duration) || (frame_diff >= -1 && time_diff >= 0)) {
+    event_fn();
+  } else {
+    rAF_reference = window.requestAnimationFrame(function(timestamp) {
+      frame_count++;
+      checkForTimeouts(timestamp, intended_delay, intended_frame_count, event_fn);
+    });
+  }
+}
+
+function next() {
+  frame_count = 0;
+  var lower_dur = Math.floor(duration/estimated_frame_duration) * estimated_frame_duration;
+  var upper_dur = Math.ceil(duration/estimated_frame_duration) * estimated_frame_duration;
+  var duration_adj;
+  if ((duration - lower_dur) <= (estimated_frame_duration/2)) {
+    duration_adj = lower_dur;
+  } else {
+    duration_adj = upper_dur;
+  }
+  var target_frame_count = duration_adj/estimated_frame_duration;
+  window.requestAnimationFrame(function(timestamp) {
+    document.querySelector('#stim').style.visibility = 'visible';
+    start_time = performance.now();
+    var rAF_reference = window.requestAnimationFrame(function(timestamp) {
+      frame_count++;
+      checkForTimeouts(timestamp, duration_adj - 5, target_frame_count, hideStim);
+    });
+  });  
+}
+
+function done() {
+  document.querySelector('html').style.height = "calc(100vh - 60px)";
+  document.querySelector('html').style.borderWidth = "30px";
+  document.querySelector('html').style.borderColor = "green";
+  document.querySelector('html').style.borderStyle = "solid";
+}
+
+</script>
+</html>


### PR DESCRIPTION
Added two rAF tests:
- rAF.html: just uses the timestamps to determine when the stim should be hidden.
- rAF_frame_counting.html: estimates the duration between frames, adjusts the target stim duration so that it's a multiple of the frame duration, and uses a combination of timestamps and frame counting to determine when the stim should be hidden.