### PR TITLE
change all_rAF_time.html timestamps

### DIFF
--- a/experiment/all_rAF_time.html
+++ b/experiment/all_rAF_time.html
@@ -20,7 +20,11 @@
 var duration = 0;
 var iti = 0;
 var trials = 0;
+
 var last_frame_time = 0;
+var raf_start_time = 0;
+var raf_current_time = 0;
+var display_duration = 0;
 
 document.querySelector('#start').addEventListener('click', beginExperiment);
 
@@ -34,7 +38,7 @@ function beginExperiment(){
 }
 
 function startTrial(ts) {
-  start_time = ts;
+  raf_start_time = performance.now();
   last_frame_time = ts;
   var html = '<div id="stim"></div>';
   document.querySelector('body').innerHTML = html;
@@ -42,11 +46,12 @@ function startTrial(ts) {
 }
 
 function checkForTimeout(ts) {
-  var last_frame_duration = ts - last_frame_time;
+  raf_current_time = performance.now();
+  display_duration = raf_current_time - raf_start_time;
+  last_frame_duration = ts - last_frame_time;
   last_frame_time = ts;
-  var display_duration = ts - start_time;
   if(display_duration >= duration - (last_frame_duration/2)){
-    endTrial(ts);
+    endTrial();
   } else {
     window.requestAnimationFrame(checkForTimeout);
   }
@@ -55,20 +60,20 @@ function checkForTimeout(ts) {
 function endTrial(ts) {
   document.querySelector('#stim').remove();
   trials--;
-  if(trials == 0){
+  if(trials === 0){
     finishExperiment();
   } else {
-    start_time = ts;
     window.requestAnimationFrame(checkForITI);
   }
 }
 
 function checkForITI(ts) {
-  var last_frame_duration = ts - last_frame_time;
+  raf_current_time = performance.now();
+  display_duration = raf_current_time - raf_start_time;
+  last_frame_duration = ts - last_frame_time;
   last_frame_time = ts;
-  var display_duration = ts - start_time;
   if(display_duration >= iti - (last_frame_duration/2)){
-    startTrial(ts);
+    startTrial();
   } else {
     window.requestAnimationFrame(checkForITI);
   }

--- a/experiment/all_rAF_time.html
+++ b/experiment/all_rAF_time.html
@@ -63,6 +63,7 @@ function endTrial(ts) {
   if(trials === 0){
     finishExperiment();
   } else {
+    raf_start_time = performance.now();
     window.requestAnimationFrame(checkForITI);
   }
 }

--- a/experiment/all_rAF_time.html
+++ b/experiment/all_rAF_time.html
@@ -51,7 +51,7 @@ function checkForTimeout(ts) {
   last_frame_duration = ts - last_frame_time;
   last_frame_time = ts;
   if(display_duration >= duration - (last_frame_duration/2)){
-    endTrial();
+    endTrial(ts);
   } else {
     window.requestAnimationFrame(checkForTimeout);
   }
@@ -74,7 +74,7 @@ function checkForITI(ts) {
   last_frame_duration = ts - last_frame_time;
   last_frame_time = ts;
   if(display_duration >= iti - (last_frame_duration/2)){
-    startTrial();
+    startTrial(ts);
   } else {
     window.requestAnimationFrame(checkForITI);
   }


### PR DESCRIPTION
This is an experiment to see if changing the timestamps will improve display duration accuracy in the rAF time version.
We were using the timestamp `ts` that is automatically passed to rAF callbacks, but this timestamp is the time that the frame's main thread starts. Instead, I'm wondering if it would help to get a performance.now() timestamp inside the callback function. See [here](https://medium.com/@paul_irish/requestanimationframe-scheduling-for-nerds-9c57f7438ef4) under 'Addendum about the rAF timestamp', and in the 'Life of a frame' figures, I think this is the difference between 'Begin frame' and 'rAF'. 
I think the timing of the frame's main thread might be more consistent over time/frames, so I'm still using the automatically-passed `ts` timestamps to determine the frame durations.
If this looks an improvement then I can change the time + frames version as well.